### PR TITLE
encode strings / chars as ascii before sending to the printer

### DIFF
--- a/adafruit_thermal_printer/thermal_printer.py
+++ b/adafruit_thermal_printer/thermal_printer.py
@@ -202,7 +202,7 @@ class ThermalPrinter:
         if char == '\r':
             return  # Strip carriage returns by skipping them.
         self._wait_timeout()
-        self._uart.write(char)
+        self._uart.write(char.encode('ascii'))
         delay = self._byte_delay_s
         # Add extra delay for newlines or moving past the last column.
         if char == '\n' or self._column == self._max_column:
@@ -238,7 +238,7 @@ class ThermalPrinter:
 
     def send_command(self, command):
         """Send a command string to the printer."""
-        self._uart.write(command)
+        self._uart.write(command.encode('ascii'))
 
     # Do initialization in warm_up instead of the initializer because this
     # initialization takes a long time (5 seconds) and shouldn't happen during

--- a/examples/thermal_printer_simpletest.py
+++ b/examples/thermal_printer_simpletest.py
@@ -5,7 +5,6 @@ import busio
 
 import adafruit_thermal_printer
 
-
 # Pick which version thermal printer class to use depending on the version of
 # your printer.  Hold the button on the printer as it's powered on and it will
 # print a test page that displays the firmware version, like 2.64, 2.68, etc.
@@ -24,6 +23,10 @@ TX = board.TX
 # as your printer is configured (print a test page by holding the button
 # during power-up and it will show the baud rate).  Most printers use 19200.
 uart = busio.UART(TX, RX, baudrate=19200)
+
+# For a computer, use the pyserial library for uart access.
+# import serial
+# uart = serial.Serial("/dev/serial0", baudrate=19200, timeout=3000)
 
 # Create the printer instance.
 printer = ThermalPrinter(uart, auto_warm_up=False)


### PR DESCRIPTION
This or something like it seems to be necessary on CPython - otherwise you get a bunch of:

```
Traceback (most recent call last):
  File "thermal_printer_simpletest.py", line 32, in <module>
    printer = ThermalPrinter(uart, auto_warm_up=False)
  File "/home/pi/Adafruit_CircuitPython_Thermal_Printer/.env/lib/python3.5/site-packages/adafruit_circuitpython_thermal_printer-1.1.1.dev1+g9d776c7.d20181002-py3.5.egg/adafruit_thermal_printer/thermal_printer.py", line 187, in __init__
  File "/home/pi/Adafruit_CircuitPython_Thermal_Printer/.env/lib/python3.5/site-packages/adafruit_circuitpython_thermal_printer-1.1.1.dev1+g9d776c7.d20181002-py3.5.egg/adafruit_thermal_printer/thermal_printer.py", line 289, in reset
  File "/home/pi/Adafruit_CircuitPython_Thermal_Printer/.env/lib/python3.5/site-packages/adafruit_circuitpython_thermal_printer-1.1.1.dev1+g9d776c7.d20181002-py3.5.egg/adafruit_thermal_printer/thermal_printer.py", line 241, in send_command
  File "/home/pi/Adafruit_CircuitPython_Thermal_Printer/.env/lib/python3.5/site-packages/serial/serialposix.py", line 532, in write
    d = to_bytes(data)
  File "/home/pi/Adafruit_CircuitPython_Thermal_Printer/.env/lib/python3.5/site-packages/serial/serialutil.py", line 63, in to_bytes
    raise TypeError('unicode strings are not supported, please encode to bytes: {!r}'.format(seq))
TypeError: unicode strings are not supported, please encode to bytes: '\x1b@'
```

I'm unsure if this is the right way to handle the problem, or if I caught everything, but the simpletest runs with these changes.  Thoughts?

(Hasn't yet been tested on CircuitPython hardware, also includes `pyserial` line in simpletest.)