### PR TITLE
README update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,9 @@ Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading
 `the Adafruit library and driver bundle <https://github.com/adafruit/Adafruit_CircuitPython_Bundle>`_.
 
+**NOTE:** This library is not supported for smaller non-Express boards like
+the Trinket M0, Gemma M0, etc.
+
 Usage Example
 =============
 
@@ -38,29 +41,6 @@ Contributions are welcome! Please read our `Code of Conduct
 <https://github.com/adafruit/Adafruit_CircuitPython_Thermal_Printer/blob/master/CODE_OF_CONDUCT.md>`_
 before contributing to help this project stay welcoming.
 
-Building locally
-================
-
-To build this library locally you'll need to install the
-`circuitpython-build-tools <https://github.com/adafruit/circuitpython-build-tools>`_ package.
-
-.. code-block:: shell
-
-    python3 -m venv .env
-    source .env/bin/activate
-    pip install circuitpython-build-tools
-
-Once installed, make sure you are in the virtual environment:
-
-.. code-block:: shell
-
-    source .env/bin/activate
-
-Then run the build:
-
-.. code-block:: shell
-
-    circuitpython-build-bundles --filename_prefix adafruit_circuitpython_thermal_printer --library_location .
 
 Sphinx documentation
 -----------------------


### PR DESCRIPTION
Per request, to call out incompatibility with non-Express boards.

Also removed the "Building locally" section which isn't part of the boiler plate readme anymore.