### PR TITLE
remove bad-whitespace pylint directive

### DIFF
--- a/adafruit_thermal_printer/thermal_printer.py
+++ b/adafruit_thermal_printer/thermal_printer.py
@@ -57,7 +57,6 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Thermal_Printer.git"
 
 
-# pylint: disable=bad-whitespace
 # Internally used constants.
 _UPDOWN_MASK = const(1 << 2)
 _BOLD_MASK = const(1 << 3)
@@ -74,7 +73,6 @@ SIZE_MEDIUM = const(1)
 SIZE_LARGE = const(2)
 UNDERLINE_THIN = const(0)
 UNDERLINE_THICK = const(1)
-# pylint: enable=bad-whitespace
 
 
 # Disable too many instance members warning.  This is not something pylint can
@@ -106,7 +104,6 @@ UNDERLINE_THICK = const(1)
 class ThermalPrinter:
     """Thermal printer for printers with firmware version 2.68 or higher."""
 
-    # pylint: disable=bad-whitespace
     # Barcode types.  These vary based on the firmware version so are made
     # as class-level variables that users can reference (i.e.
     # ThermalPrinter.UPC_A, etc) and write code that is independent of the
@@ -120,7 +117,6 @@ class ThermalPrinter:
     CODABAR = 71
     CODE93 = 72
     CODE128 = 73
-    # pylint: enable=bad-whitespace
 
     class _PrintModeBit:
         # Internal descriptor class to simplify printer mode change properties.

--- a/adafruit_thermal_printer/thermal_printer_264.py
+++ b/adafruit_thermal_printer/thermal_printer_264.py
@@ -43,10 +43,8 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Thermal_Printer.git"
 
 
-# pylint: disable=bad-whitespace
 # Internally used constants.
 _INVERSE_MASK = const(1 << 1)  # Not in 2.6.8 firmware
-# pylint: enable=bad-whitespace
 
 
 # Legacy behavior class for printers with firmware 2.64 up to 2.68.
@@ -57,7 +55,6 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
     NOT including) 2.68.
     """
 
-    # pylint: disable=bad-whitespace
     # Barcode types.  These vary based on the firmware version so are made
     # as class-level variables that users can reference (i.e.
     # ThermalPrinter.UPC_A, etc) and write code that is independent of the
@@ -71,7 +68,6 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
     CODABAR = 71
     CODE93 = 72
     CODE128 = 73
-    # pylint: enable=bad-whitespace
 
     def __init__(
         self, uart, byte_delay_s=0.00057346, dot_feed_s=0.0021, dot_print_s=0.03

--- a/adafruit_thermal_printer/thermal_printer_legacy.py
+++ b/adafruit_thermal_printer/thermal_printer_legacy.py
@@ -43,10 +43,8 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Thermal_Printer.git"
 
 
-# pylint: disable=bad-whitespace
 # Internally used constants.
 _INVERSE_MASK = const(1 << 1)  # Not in 2.6.8 firmware
-# pylint: enable=bad-whitespace
 
 
 # Legacy behavior class for printers with firmware before 2.64.
@@ -55,7 +53,6 @@ _INVERSE_MASK = const(1 << 1)  # Not in 2.6.8 firmware
 class ThermalPrinter(thermal_printer.ThermalPrinter):
     """Thermal printer for printers with firmware version before 2.64."""
 
-    # pylint: disable=bad-whitespace
     # Barcode types.  These vary based on the firmware version so are made
     # as class-level variables that users can reference (i.e.
     # ThermalPrinter.UPC_A, etc) and write code that is independent of the
@@ -71,7 +68,6 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
     CODE128 = 8
     CODE11 = 9
     MSI = 10
-    # pylint: enable=bad-whitespace
 
     def __init__(
         self, uart, byte_delay_s=0.00057346, dot_feed_s=0.0021, dot_print_s=0.03


### PR DESCRIPTION
This directive has been removed from pylint 2.6.0.