### PR TITLE
Added support for CSN A2L with firmware 2.168

### DIFF
--- a/adafruit_thermal_printer/__init__.py
+++ b/adafruit_thermal_printer/__init__.py
@@ -32,8 +32,8 @@ def get_printer_class(version):
 
     # I reversed order of checking the version
 
-    #TODO the legacy printer should be a base class for all newer printer. It'll make it easier
-    #to upgrade the library with newer firmware
+    # TODO the legacy printer should be a base class for all newer printer. It'll make it easier
+    # to upgrade the library with newer firmware
     if version >= 2.168:
         import adafruit_thermal_printer.thermal_printer_2168 as thermal_printer
     elif version >= 2.68:
@@ -42,6 +42,6 @@ def get_printer_class(version):
         import adafruit_thermal_printer.thermal_printer_264 as thermal_printer
     else:
         import adafruit_thermal_printer.thermal_printer_legacy as thermal_printer
-    
+
     # pylint: enable=import-outside-toplevel
     return thermal_printer.ThermalPrinter

--- a/adafruit_thermal_printer/__init__.py
+++ b/adafruit_thermal_printer/__init__.py
@@ -29,11 +29,19 @@ def get_printer_class(version):
     assert version is not None
     assert version >= 0.0
     # pylint: disable=import-outside-toplevel
-    if version < 2.64:
-        import adafruit_thermal_printer.thermal_printer_legacy as thermal_printer
-    elif version < 2.68:
+
+    # I reversed order of checking the version
+
+    #TODO the legacy printer should be a base class for all newer printer. It'll make it easier
+    #to upgrade the library with newer firmware
+    if version >= 2.168:
+        import adafruit_thermal_printer.thermal_printer_2168 as thermal_printer
+    elif version >= 2.68:
+        import adafruit_thermal_printer.thermal_printer as thermal_printer
+    elif version >= 2.64:
         import adafruit_thermal_printer.thermal_printer_264 as thermal_printer
     else:
-        import adafruit_thermal_printer.thermal_printer as thermal_printer
+        import adafruit_thermal_printer.thermal_printer_legacy as thermal_printer
+    
     # pylint: enable=import-outside-toplevel
     return thermal_printer.ThermalPrinter

--- a/adafruit_thermal_printer/thermal_printer.py
+++ b/adafruit_thermal_printer/thermal_printer.py
@@ -387,8 +387,9 @@ class ThermalPrinter:
         self.size = SIZE_SMALL
         self.underline = None
         self.inverse = False
-        self.upside_down = False  # wg. dokumentacji powinno działać ale nie działa
-        self.up_down_mode = True  # zamiast powyższego zaiplementowałem to   <<
+        self.upside_down = False  # this should work in 2.68 according to user manual v 4.0 
+                                  # but it does't work with 2.168 hence i implemented the below        
+        self.up_down_mode = True 
         self.double_height = False
         self.double_width = False
         self.strike = False

--- a/adafruit_thermal_printer/thermal_printer.py
+++ b/adafruit_thermal_printer/thermal_printer.py
@@ -387,9 +387,10 @@ class ThermalPrinter:
         self.size = SIZE_SMALL
         self.underline = None
         self.inverse = False
-        self.upside_down = False  # this should work in 2.68 according to user manual v 4.0 
-                                  # but it does't work with 2.168 hence i implemented the below        
-        self.up_down_mode = True 
+        self.upside_down = False
+        # this should work in 2.68 according to user manual v 4.0
+        # but it does't work with 2.168 hence i implemented the below
+        self.up_down_mode = True
         self.double_height = False
         self.double_width = False
         self.strike = False

--- a/adafruit_thermal_printer/thermal_printer.py
+++ b/adafruit_thermal_printer/thermal_printer.py
@@ -320,15 +320,7 @@ class ThermalPrinter:
             self._write_char(char)
         if end is not None:
             self._write_char(end)
-    # def upDownMode(self, val):
-    #     """ Turns on/off upside-down printing mode (ESC + { + n)
-    #     where n is 0 or 1
-    #
-    #     """
-    #     if val is True:
-    #         self.send_command("\x1B{\x01")
-    #     else:
-    #         self.send_command("\x1B{\x00")
+
 
 
     def print_barcode(self, text, barcode_type):
@@ -516,9 +508,9 @@ class ThermalPrinter:
 
 
 
-    up_down_mode = property(None, _set_up_down_mode, None, "Turns on/off upside-down printing mode")
+    up_down_mode = property(None, _set_up_down_mode, None, "Turns on/off upside-down printing mode") #Should work in 2.68 so its here and not in 2.168 module
 
-    upside_down = _PrintModeBit(_UPDOWN_MASK)   #wg. dokumentacji to powinno działać ale nie działa
+    upside_down = _PrintModeBit(_UPDOWN_MASK)   #Don't work in 2.168 hence the above
 
     double_height = _PrintModeBit(_DOUBLE_HEIGHT_MASK)
 

--- a/adafruit_thermal_printer/thermal_printer.py
+++ b/adafruit_thermal_printer/thermal_printer.py
@@ -57,7 +57,6 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Thermal_Printer.git"
 
 
- 
 # Internally used constants.
 _UPDOWN_MASK = const(1 << 2)
 _BOLD_MASK = const(1 << 3)
@@ -74,7 +73,6 @@ SIZE_MEDIUM = const(1)
 SIZE_LARGE = const(2)
 UNDERLINE_THIN = const(0)
 UNDERLINE_THICK = const(1)
- 
 
 
 # Disable too many instance members warning.  This is not something pylint can
@@ -119,7 +117,7 @@ class ThermalPrinter:
     CODABAR = 71
     CODE93 = 72
     CODE128 = 73
-     
+
     class _PrintModeBit:
         # Internal descriptor class to simplify printer mode change properties.
         # This is tightly coupled to the ThermalPrinter implementation--do not
@@ -152,16 +150,14 @@ class ThermalPrinter:
         # pylint: enable=too-few-public-methods
 
 
-
-
     def __init__(
-        self,
-        uart,
-        *,
-        byte_delay_s=0.00057346,
-        dot_feed_s=0.0021,
-        dot_print_s=0.03,
-        auto_warm_up=True
+            self,
+            uart,
+            *,
+            byte_delay_s=0.00057346,
+            dot_feed_s=0.0021,
+            dot_print_s=0.03,
+            auto_warm_up=True
     ):
         """Thermal printer class.  Requires a serial UART connection with at
         least the TX pin connected.  Take care connecting RX as the printer
@@ -506,7 +502,8 @@ class ThermalPrinter:
 
 
 
-    up_down_mode = property(None, _set_up_down_mode, None, "Turns on/off upside-down printing mode") #Should work in 2.68 so its here and not in 2.168 module
+    up_down_mode = property(None, _set_up_down_mode, None, "Turns on/off upside-down printing mode") 
+    #The above Should work in 2.68 so its here and not in 2.168 module
 
     upside_down = _PrintModeBit(_UPDOWN_MASK)   #Don't work in 2.168 hence the above
 

--- a/adafruit_thermal_printer/thermal_printer.py
+++ b/adafruit_thermal_printer/thermal_printer.py
@@ -149,15 +149,14 @@ class ThermalPrinter:
         # pylint: enable=protected-access
         # pylint: enable=too-few-public-methods
 
-
     def __init__(
-            self,
-            uart,
-            *,
-            byte_delay_s=0.00057346,
-            dot_feed_s=0.0021,
-            dot_print_s=0.03,
-            auto_warm_up=True
+        self,
+        uart,
+        *,
+        byte_delay_s=0.00057346,
+        dot_feed_s=0.0021,
+        dot_print_s=0.03,
+        auto_warm_up=True
     ):
         """Thermal printer class.  Requires a serial UART connection with at
         least the TX pin connected.  Take care connecting RX as the printer
@@ -315,8 +314,6 @@ class ThermalPrinter:
         if end is not None:
             self._write_char(end)
 
-
-
     def print_barcode(self, text, barcode_type):
         """Print a barcode with the specified text/number (the meaning
         varies based on the type of barcode) and type.  Type is a value from
@@ -390,8 +387,8 @@ class ThermalPrinter:
         self.size = SIZE_SMALL
         self.underline = None
         self.inverse = False
-        self.upside_down = False            # wg. dokumentacji powinno działać ale nie działa
-        self.up_down_mode = True            # zamiast powyższego zaiplementowałem to   <<
+        self.upside_down = False  # wg. dokumentacji powinno działać ale nie działa
+        self.up_down_mode = True  # zamiast powyższego zaiplementowałem to   <<
         self.double_height = False
         self.double_width = False
         self.strike = False
@@ -499,13 +496,12 @@ class ThermalPrinter:
         else:
             self.send_command("\x1B{\x00")
 
+    up_down_mode = property(
+        None, _set_up_down_mode, None, "Turns on/off upside-down printing mode"
+    )
+    # The above Should work in 2.68 so its here and not in 2.168 module
 
-
-
-    up_down_mode = property(None, _set_up_down_mode, None, "Turns on/off upside-down printing mode") 
-    #The above Should work in 2.68 so its here and not in 2.168 module
-
-    upside_down = _PrintModeBit(_UPDOWN_MASK)   #Don't work in 2.168 hence the above
+    upside_down = _PrintModeBit(_UPDOWN_MASK)  # Don't work in 2.168 hence the above
 
     double_height = _PrintModeBit(_DOUBLE_HEIGHT_MASK)
 
@@ -540,8 +536,7 @@ class ThermalPrinter:
         self.send_command("\x1B=\x00")  # ESC + '=' + 0
 
     def online(self):
-        """Put the printer into an online state after previously put offline.
-        """
+        """Put the printer into an online state after previously put offline."""
         self.send_command("\x1B=\x01")  # ESC + '=' + 1
 
     def has_paper(self):

--- a/adafruit_thermal_printer/thermal_printer.py
+++ b/adafruit_thermal_printer/thermal_printer.py
@@ -57,7 +57,7 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Thermal_Printer.git"
 
 
-# pylint: disable=bad-whitespace
+ 
 # Internally used constants.
 _UPDOWN_MASK = const(1 << 2)
 _BOLD_MASK = const(1 << 3)
@@ -74,7 +74,7 @@ SIZE_MEDIUM = const(1)
 SIZE_LARGE = const(2)
 UNDERLINE_THIN = const(0)
 UNDERLINE_THICK = const(1)
-# pylint: enable=bad-whitespace
+ 
 
 
 # Disable too many instance members warning.  This is not something pylint can
@@ -106,7 +106,6 @@ UNDERLINE_THICK = const(1)
 class ThermalPrinter:
     """Thermal printer for printers with firmware version from 2.68 and below 2.168"""
 
-    # pylint: disable=bad-whitespace
     # Barcode types.  These vary based on the firmware version so are made
     # as class-level variables that users can reference (i.e.
     # ThermalPrinter.UPC_A, etc) and write code that is independent of the
@@ -120,8 +119,7 @@ class ThermalPrinter:
     CODABAR = 71
     CODE93 = 72
     CODE128 = 73
-    # pylint: enable=bad-whitespace
-
+     
     class _PrintModeBit:
         # Internal descriptor class to simplify printer mode change properties.
         # This is tightly coupled to the ThermalPrinter implementation--do not

--- a/adafruit_thermal_printer/thermal_printer.py
+++ b/adafruit_thermal_printer/thermal_printer.py
@@ -57,6 +57,7 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Thermal_Printer.git"
 
 
+# pylint: disable=bad-whitespace
 # Internally used constants.
 _UPDOWN_MASK = const(1 << 2)
 _BOLD_MASK = const(1 << 3)
@@ -73,6 +74,7 @@ SIZE_MEDIUM = const(1)
 SIZE_LARGE = const(2)
 UNDERLINE_THIN = const(0)
 UNDERLINE_THICK = const(1)
+# pylint: enable=bad-whitespace
 
 
 # Disable too many instance members warning.  This is not something pylint can
@@ -102,8 +104,9 @@ UNDERLINE_THICK = const(1)
 # else it will be very easy to break or introduce subtle incompatibilities with
 # older firmware printers.
 class ThermalPrinter:
-    """Thermal printer for printers with firmware version 2.68 or higher."""
+    """Thermal printer for printers with firmware version from 2.68 and below 2.168"""
 
+    # pylint: disable=bad-whitespace
     # Barcode types.  These vary based on the firmware version so are made
     # as class-level variables that users can reference (i.e.
     # ThermalPrinter.UPC_A, etc) and write code that is independent of the
@@ -117,6 +120,7 @@ class ThermalPrinter:
     CODABAR = 71
     CODE93 = 72
     CODE128 = 73
+    # pylint: enable=bad-whitespace
 
     class _PrintModeBit:
         # Internal descriptor class to simplify printer mode change properties.
@@ -149,6 +153,9 @@ class ThermalPrinter:
         # pylint: enable=protected-access
         # pylint: enable=too-few-public-methods
 
+
+
+
     def __init__(
         self,
         uart,
@@ -180,6 +187,7 @@ class ThermalPrinter:
         self._char_height = 24
         self._line_spacing = 6
         self._barcode_height = 50
+        self.up_down_mode = True
         # pylint: disable=line-too-long
         # Byte delay calculated based on assumption of 19200 baud.
         # From Arduino library code, see formula here:
@@ -312,6 +320,16 @@ class ThermalPrinter:
             self._write_char(char)
         if end is not None:
             self._write_char(end)
+    # def upDownMode(self, val):
+    #     """ Turns on/off upside-down printing mode (ESC + { + n)
+    #     where n is 0 or 1
+    #
+    #     """
+    #     if val is True:
+    #         self.send_command("\x1B{\x01")
+    #     else:
+    #         self.send_command("\x1B{\x00")
+
 
     def print_barcode(self, text, barcode_type):
         """Print a barcode with the specified text/number (the meaning
@@ -386,7 +404,8 @@ class ThermalPrinter:
         self.size = SIZE_SMALL
         self.underline = None
         self.inverse = False
-        self.upside_down = False
+        self.upside_down = False            # wg. dokumentacji powinno działać ale nie działa
+        self.up_down_mode = True            # zamiast powyższego zaiplementowałem to   <<
         self.double_height = False
         self.double_width = False
         self.strike = False
@@ -487,7 +506,19 @@ class ThermalPrinter:
     )
     # pylint: enable=line-too-long
 
-    upside_down = _PrintModeBit(_UPDOWN_MASK)
+    def _set_up_down_mode(self, up_down_mode):
+        if up_down_mode:
+            self.send_command("\x1B{\x01")
+
+        else:
+            self.send_command("\x1B{\x00")
+
+
+
+
+    up_down_mode = property(None, _set_up_down_mode, None, "Turns on/off upside-down printing mode")
+
+    upside_down = _PrintModeBit(_UPDOWN_MASK)   #wg. dokumentacji to powinno działać ale nie działa
 
     double_height = _PrintModeBit(_DOUBLE_HEIGHT_MASK)
 

--- a/adafruit_thermal_printer/thermal_printer_2168.py
+++ b/adafruit_thermal_printer/thermal_printer_2168.py
@@ -41,6 +41,7 @@ package for your firmware printer:
 import adafruit_thermal_printer.thermal_printer as thermal_printer
 
 
+# pylint: disable=too-many-arguments
 class ThermalPrinter(thermal_printer.ThermalPrinter):
     """Thermal printer for printers with firmware version from 2.168"""
 
@@ -58,7 +59,6 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
     CODE93 = 72
     CODE128 = 73
 
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
         uart,
@@ -67,7 +67,6 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
         dot_print_s=0.03,
         auto_warm_up=True,
     ):
-        # pylint: enable=too-many-arguments
         """Thermal printer class.  Requires a serial UART connection with at
         least the TX pin connected.  Take care connecting RX as the printer
         will output a 5V signal which can damage boards!  If RX is unconnected

--- a/adafruit_thermal_printer/thermal_printer_2168.py
+++ b/adafruit_thermal_printer/thermal_printer_2168.py
@@ -37,7 +37,6 @@ package for your firmware printer:
 * Author(s): Tony DiCola, Grzegorz Nowicki
 """
 
-from micropython import const
 
 import adafruit_thermal_printer.thermal_printer as thermal_printer
 
@@ -59,6 +58,7 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
     CODE93 = 72
     CODE128 = 73
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         uart,
@@ -67,6 +67,7 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
         dot_print_s=0.03,
         auto_warm_up=True,
     ):
+    # pylint: enable=too-many-arguments
         """Thermal printer class.  Requires a serial UART connection with at
         least the TX pin connected.  Take care connecting RX as the printer
         will output a 5V signal which can damage boards!  If RX is unconnected
@@ -84,6 +85,7 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
             dot_print_s=dot_print_s,
             auto_warm_up=auto_warm_up,
         )
+
 
     def warm_up(self, heat_time=120):
         """Apparently there are no parameters for setting darkness in 2.168

--- a/adafruit_thermal_printer/thermal_printer_2168.py
+++ b/adafruit_thermal_printer/thermal_printer_2168.py
@@ -67,7 +67,7 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
         dot_print_s=0.03,
         auto_warm_up=True,
     ):
-    # pylint: enable=too-many-arguments
+        # pylint: enable=too-many-arguments
         """Thermal printer class.  Requires a serial UART connection with at
         least the TX pin connected.  Take care connecting RX as the printer
         will output a 5V signal which can damage boards!  If RX is unconnected
@@ -85,7 +85,6 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
             dot_print_s=dot_print_s,
             auto_warm_up=auto_warm_up,
         )
-
 
     def warm_up(self, heat_time=120):
         """Apparently there are no parameters for setting darkness in 2.168

--- a/adafruit_thermal_printer/thermal_printer_2168.py
+++ b/adafruit_thermal_printer/thermal_printer_2168.py
@@ -1,0 +1,90 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2020 Grzegorz Nowicki
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+`adafruit_thermal_printer.thermal_printer_2168.ThermalPrinter`
+==============================================================
+
+Thermal printer control module built to work with small serial thermal
+receipt printers.  Note that these printers have many different firmware
+versions and care must be taken to select the appropriate module inside this
+package for your firmware printer:
+
+* thermal_printer_2164 = Printers with firmware version 2.168+.
+* thermal_printer = The latest printers with firmware version 2.68 up to 2.168
+* thermal_printer_264 = Printers with firmware version 2.64 up to 2.68.
+* thermal_printer_legacy = Printers with firmware version before 2.64.
+
+* Author(s): Tony DiCola, Grzegorz Nowicki
+"""
+
+from micropython import const
+
+import adafruit_thermal_printer.thermal_printer as thermal_printer
+
+class ThermalPrinter(thermal_printer.ThermalPrinter):
+    """Thermal printer for printers with firmware version from 2.168
+    """
+
+    # Barcode types.  These vary based on the firmware version so are made
+    # as class-level variables that users can reference (i.e.
+    # ThermalPrinter.UPC_A, etc) and write code that is independent of the
+    # printer firmware version.
+    UPC_A = 65
+    UPC_E = 66
+    EAN13 = 67
+    EAN8 = 68
+    CODE39 = 69
+    ITF = 70
+    CODABAR = 71
+    CODE93 = 72
+    CODE128 = 73
+
+    def __init__(
+        self, uart, byte_delay_s=0.00057346, dot_feed_s=0.0021, dot_print_s=0.03, auto_warm_up=True
+    ):
+        """Thermal printer class.  Requires a serial UART connection with at
+        least the TX pin connected.  Take care connecting RX as the printer
+        will output a 5V signal which can damage boards!  If RX is unconnected
+        the only loss in functionality is the has_paper function, all other
+        printer functions will continue to work.  The byte_delay_s, dot_feed_s,
+        and dot_print_s values are delays which are used to prevent overloading
+        the printer with data.  Use the default delays unless you fully
+        understand the workings of the printer and how delays, baud rate,
+        number of dots, heat time, etc. relate to each other.
+        """
+        super().__init__(
+            uart,
+            byte_delay_s=byte_delay_s,
+            dot_feed_s=dot_feed_s,
+            dot_print_s=dot_print_s,
+            auto_warm_up=auto_warm_up
+        )
+
+    def warm_up(self, heat_time=120):
+        """Apparently there are no parameters for setting darkness in 2.168 (at least commands from 2.68 dont work),
+        So it is little compatibility method to reuse older code. 
+        """        
+        self._set_timeout(0.5)  # Half second delay for printer to initialize.
+        self.reset()
+
+    

--- a/adafruit_thermal_printer/thermal_printer_2168.py
+++ b/adafruit_thermal_printer/thermal_printer_2168.py
@@ -60,7 +60,7 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
     CODE128 = 73
 
     def __init__(
-        self, uart, byte_delay_s=0.00057346, dot_feed_s=0.0021, dot_print_s=0.03, auto_warm_up=True
+            self, uart, byte_delay_s=0.00057346, dot_feed_s=0.0021, dot_print_s=0.03, auto_warm_up=True
     ):
         """Thermal printer class.  Requires a serial UART connection with at
         least the TX pin connected.  Take care connecting RX as the printer
@@ -81,10 +81,9 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
         )
 
     def warm_up(self, heat_time=120):
-        """Apparently there are no parameters for setting darkness in 2.168 (at least commands from 2.68 dont work),
-        So it is little compatibility method to reuse older code. 
-        """        
+        """Apparently there are no parameters for setting darkness in 2.168 
+        (at least commands from 2.68 dont work), So it is little
+        compatibility method to reuse older code. 
+        """
         self._set_timeout(0.5)  # Half second delay for printer to initialize.
         self.reset()
-
-    

--- a/adafruit_thermal_printer/thermal_printer_2168.py
+++ b/adafruit_thermal_printer/thermal_printer_2168.py
@@ -29,7 +29,7 @@ receipt printers.  Note that these printers have many different firmware
 versions and care must be taken to select the appropriate module inside this
 package for your firmware printer:
 
-* thermal_printer_2164 = Printers with firmware version 2.168+.
+* thermal_printer_2168 = Printers with firmware version 2.168+.
 * thermal_printer = The latest printers with firmware version 2.68 up to 2.168
 * thermal_printer_264 = Printers with firmware version 2.64 up to 2.68.
 * thermal_printer_legacy = Printers with firmware version before 2.64.

--- a/adafruit_thermal_printer/thermal_printer_2168.py
+++ b/adafruit_thermal_printer/thermal_printer_2168.py
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2020 Grzegorz Nowicki
+# Copyright (c) 2020 Tony DiCola, Grzegorz Nowicki
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/adafruit_thermal_printer/thermal_printer_2168.py
+++ b/adafruit_thermal_printer/thermal_printer_2168.py
@@ -41,9 +41,9 @@ from micropython import const
 
 import adafruit_thermal_printer.thermal_printer as thermal_printer
 
+
 class ThermalPrinter(thermal_printer.ThermalPrinter):
-    """Thermal printer for printers with firmware version from 2.168
-    """
+    """Thermal printer for printers with firmware version from 2.168"""
 
     # Barcode types.  These vary based on the firmware version so are made
     # as class-level variables that users can reference (i.e.
@@ -60,7 +60,12 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
     CODE128 = 73
 
     def __init__(
-            self, uart, byte_delay_s=0.00057346, dot_feed_s=0.0021, dot_print_s=0.03, auto_warm_up=True
+        self,
+        uart,
+        byte_delay_s=0.00057346,
+        dot_feed_s=0.0021,
+        dot_print_s=0.03,
+        auto_warm_up=True,
     ):
         """Thermal printer class.  Requires a serial UART connection with at
         least the TX pin connected.  Take care connecting RX as the printer
@@ -77,13 +82,13 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
             byte_delay_s=byte_delay_s,
             dot_feed_s=dot_feed_s,
             dot_print_s=dot_print_s,
-            auto_warm_up=auto_warm_up
+            auto_warm_up=auto_warm_up,
         )
 
     def warm_up(self, heat_time=120):
-        """Apparently there are no parameters for setting darkness in 2.168 
+        """Apparently there are no parameters for setting darkness in 2.168
         (at least commands from 2.68 dont work), So it is little
-        compatibility method to reuse older code. 
+        compatibility method to reuse older code.
         """
         self._set_timeout(0.5)  # Half second delay for printer to initialize.
         self.reset()

--- a/adafruit_thermal_printer/thermal_printer_264.py
+++ b/adafruit_thermal_printer/thermal_printer_264.py
@@ -71,7 +71,7 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
     CODE128 = 73
 
     def __init__(
-            self, uart, byte_delay_s=0.00057346, dot_feed_s=0.0021, dot_print_s=0.03
+        self, uart, byte_delay_s=0.00057346, dot_feed_s=0.0021, dot_print_s=0.03
     ):
         """Thermal printer class.  Requires a serial UART connection with at
         least the TX pin connected.  Take care connecting RX as the printer

--- a/adafruit_thermal_printer/thermal_printer_264.py
+++ b/adafruit_thermal_printer/thermal_printer_264.py
@@ -28,7 +28,8 @@ receipt printers.  Note that these printers have many different firmware
 versions and care must be taken to select the appropriate module inside this
 package for your firmware printer:
 
-* thermal_printer = The latest printers with firmware version 2.68+
+* thermal_printer_2164 = Printers with firmware version 2.168+.
+* thermal_printer = The latest printers with firmware version 2.68 up to 2.168
 * thermal_printer_264 = Printers with firmware version 2.64 up to 2.68.
 * thermal_printer_legacy = Printers with firmware version before 2.64.
 

--- a/adafruit_thermal_printer/thermal_printer_264.py
+++ b/adafruit_thermal_printer/thermal_printer_264.py
@@ -71,7 +71,7 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
     CODE128 = 73
 
     def __init__(
-        self, uart, byte_delay_s=0.00057346, dot_feed_s=0.0021, dot_print_s=0.03
+            self, uart, byte_delay_s=0.00057346, dot_feed_s=0.0021, dot_print_s=0.03
     ):
         """Thermal printer class.  Requires a serial UART connection with at
         least the TX pin connected.  Take care connecting RX as the printer

--- a/adafruit_thermal_printer/thermal_printer_264.py
+++ b/adafruit_thermal_printer/thermal_printer_264.py
@@ -28,7 +28,7 @@ receipt printers.  Note that these printers have many different firmware
 versions and care must be taken to select the appropriate module inside this
 package for your firmware printer:
 
-* thermal_printer_2164 = Printers with firmware version 2.168+.
+* thermal_printer_2168 = Printers with firmware version 2.168+.
 * thermal_printer = The latest printers with firmware version 2.68 up to 2.168
 * thermal_printer_264 = Printers with firmware version 2.64 up to 2.68.
 * thermal_printer_legacy = Printers with firmware version before 2.64.

--- a/adafruit_thermal_printer/thermal_printer_legacy.py
+++ b/adafruit_thermal_printer/thermal_printer_legacy.py
@@ -28,7 +28,8 @@ receipt printers.  Note that these printers have many different firmware
 versions and care must be taken to select the appropriate module inside this
 package for your firmware printer:
 
-* thermal_printer = The latest printers with firmware version 2.68+
+* thermal_printer_2164 = Printers with firmware version 2.168+.
+* thermal_printer = The latest printers with firmware version 2.68 up to 2.168
 * thermal_printer_264 = Printers with firmware version 2.64 up to 2.68.
 * thermal_printer_legacy = Printers with firmware version before 2.64.
 

--- a/adafruit_thermal_printer/thermal_printer_legacy.py
+++ b/adafruit_thermal_printer/thermal_printer_legacy.py
@@ -28,7 +28,7 @@ receipt printers.  Note that these printers have many different firmware
 versions and care must be taken to select the appropriate module inside this
 package for your firmware printer:
 
-* thermal_printer_2164 = Printers with firmware version 2.168+.
+* thermal_printer_2168 = Printers with firmware version 2.168+.
 * thermal_printer = The latest printers with firmware version 2.68 up to 2.168
 * thermal_printer_264 = Printers with firmware version 2.64 up to 2.68.
 * thermal_printer_legacy = Printers with firmware version before 2.64.

--- a/adafruit_thermal_printer/thermal_printer_legacy.py
+++ b/adafruit_thermal_printer/thermal_printer_legacy.py
@@ -71,7 +71,7 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
     MSI = 10
 
     def __init__(
-        self, uart, byte_delay_s=0.00057346, dot_feed_s=0.0021, dot_print_s=0.03
+            self, uart, byte_delay_s=0.00057346, dot_feed_s=0.0021, dot_print_s=0.03
     ):
         """Thermal printer class.  Requires a serial UART connection with at
         least the TX pin connected.  Take care connecting RX as the printer

--- a/adafruit_thermal_printer/thermal_printer_legacy.py
+++ b/adafruit_thermal_printer/thermal_printer_legacy.py
@@ -71,7 +71,7 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
     MSI = 10
 
     def __init__(
-            self, uart, byte_delay_s=0.00057346, dot_feed_s=0.0021, dot_print_s=0.03
+        self, uart, byte_delay_s=0.00057346, dot_feed_s=0.0021, dot_print_s=0.03
     ):
         """Thermal printer class.  Requires a serial UART connection with at
         least the TX pin connected.  Take care connecting RX as the printer


### PR DESCRIPTION
Creating separate subclass for new firmware. It resolves issue  #18 of printing leftover characters as new firmware doesn't support darkness manipulation commands.

I did not go through whole new manual to check for other changes. I'll be adding them on the go (or someone else can)