### PR TITLE
Add ability to print bitmaps

### DIFF
--- a/adafruit_thermal_printer/thermal_printer_2168.py
+++ b/adafruit_thermal_printer/thermal_printer_2168.py
@@ -99,9 +99,11 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
         """ Convert bitmap file and print as picture using GS v 0 command """
         # pylint: disable=too-many-locals
         img = imageio.imread(file)
+        # pylint: disable=unused-variable
         try:
             if img.shape[2] == 4:  # 3 colors with alpha channel
                 red, green, blue, alpha = np.split(img, 4, axis=2)
+        # pylint: enable=unused-variable
             else:  # just 3 colors
                 red, green, blue = np.split(img, 3, axis=2)
 
@@ -163,6 +165,7 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
 
     def _write_to_byte(self, pos, byte):
         """Helper method used in _convert_data_horizontally to compress pixel data into bytes"""
+        # pylint: disable=too-many-return-statements
         if pos == 0:
             return byte | 0b10000000
         if pos == 1:
@@ -179,6 +182,7 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
             return byte | 0b00000010
         if pos == 7:
             return byte | 0b00000001
+        # pylint: enable=too-many-return-statements
 
     def _convert_data_horizontally(self, data_array):
         """Convert data from numpy array format to printer's horizontal printing module format"""

--- a/adafruit_thermal_printer/thermal_printer_2168.py
+++ b/adafruit_thermal_printer/thermal_printer_2168.py
@@ -29,7 +29,7 @@ receipt printers.  Note that these printers have many different firmware
 versions and care must be taken to select the appropriate module inside this
 package for your firmware printer:
 
-* thermal_printer_2164 = Printers with firmware version 2.168+.
+* thermal_printer_2168 = Printers with firmware version 2.168+.
 * thermal_printer = The latest printers with firmware version 2.68 up to 2.168
 * thermal_printer_264 = Printers with firmware version 2.64 up to 2.68.
 * thermal_printer_legacy = Printers with firmware version before 2.64.

--- a/adafruit_thermal_printer/thermal_printer_2168.py
+++ b/adafruit_thermal_printer/thermal_printer_2168.py
@@ -100,13 +100,14 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
         # pylint: disable=too-many-locals
         img = imageio.imread(file)
         # pylint: disable=unused-variable
+        # pylint: disable=unbalanced-tuple-unpacking
         try:
             if img.shape[2] == 4:  # 3 colors with alpha channel
                 red, green, blue, alpha = np.split(img, 4, axis=2)
-        # pylint: enable=unused-variable
+            # pylint: enable=unused-variable
             else:  # just 3 colors
                 red, green, blue = np.split(img, 3, axis=2)
-
+            # pylint: enable=unbalanced-tuple-unpacking
             red = red.reshape(-1)
             green = green.reshape(-1)
             blue = blue.reshape(-1)
@@ -163,9 +164,11 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
             self._uart.write(d)
         # pylint: enable=invalid-name
 
+    # pylint: disable=no-self-use
     def _write_to_byte(self, pos, byte):
         """Helper method used in _convert_data_horizontally to compress pixel data into bytes"""
         # pylint: disable=too-many-return-statements
+
         if pos == 0:
             return byte | 0b10000000
         if pos == 1:
@@ -182,7 +185,10 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
             return byte | 0b00000010
         if pos == 7:
             return byte | 0b00000001
+        return byte | 0b00000000
         # pylint: enable=too-many-return-statements
+
+    # pylint: enable=no-self-use
 
     def _convert_data_horizontally(self, data_array):
         """Convert data from numpy array format to printer's horizontal printing module format"""
@@ -191,6 +197,7 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
 
         datas = bytearray()
         # pylint: disable=invalid-name
+        # pylint: disable=too-many-nested-blocks
         for y in range(y_size):
             for x in range(0, x_size, 8):
                 data = 0
@@ -205,4 +212,5 @@ class ThermalPrinter(thermal_printer.ThermalPrinter):
                         pass
                 datas.append(data)
         return datas
+        # pylint: enable=too-many-nested-blocks
         # pylint: enable=invalid-name

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Adafruit-Blinka
 pyserial
+imageio
+numpy


### PR DESCRIPTION
Works at firmware 2.168. Should work on 2.68 but all the new methods are contained in thermal_printer_2168.py file.

I tested only on printing bitmaps so setting timeouts for communication was irrelevant but if it will be I'll fix it

Potentially closes  #16