### PR TITLE
update readthedocs link and badge URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 Introduction
 ============
 
-.. image:: https://readthedocs.org/projects/adafruit_circuitpython_thermal_printer/badge/?version=latest
-    :target: https://adafruit_circuitpython_thermal_printer.readthedocs.io/
+.. image:: https://readthedocs.org/projects/adafruit-circuitpython-thermal-printer/badge/?version=latest
+    :target: https://circuitpython.readthedocs.io/projects/thermal_printer/en/latest/
     :alt: Documentation Status
 
 .. image :: https://img.shields.io/discord/327254708534116352.svg


### PR DESCRIPTION
This updates the readthedocs link in the readme, and the URL for the badge image to match the way the rest of the URLs in the other repos work.

This does not actually change the functionality at all because it seems like both URLs for the docs and the badge do get redirected to the right spot. But making this change will allow the script to add a text docs link less complex because it won't need a special exception for this one repo.