### PR TITLE
Fix pylint errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         name: pylint (library code)
         types: [python]
         args:
-          - --disable=consider-using-f-string
+          - --disable=consider-using-f-string,duplicate-code
         exclude: "^(docs/|examples/|tests/|setup.py$)"
       - id: pylint
         name: pylint (example code)


### PR DESCRIPTION
Fixed the following `pylint` errors:

```
Error: pylint (library code)....................................................Failed
- hook id: pylint
- exit code: 8

************* Module adafruit_thermal_printer.thermal_printer_legacy
adafruit_thermal_printer/thermal_printer_legacy.py:1:0: R0801: Similar lines in 2 files
==adafruit_thermal_printer.thermal_printer_2168:[27:67]
==adafruit_thermal_printer.thermal_printer_264:[36:73]
class ThermalPrinter(thermal_printer.ThermalPrinter):
    """Thermal printer for printers with firmware version 2.64 up to (but
    NOT including) 2.68.
    """

    # Barcode types.  These vary based on the firmware version so are made
    # as class-level variables that users can reference (i.e.
    # ThermalPrinter.UPC_A, etc) and write code that is independent of the
    # printer firmware version.
    UPC_A = 65
    UPC_E = 66
    EAN13 = 67
    EAN8 = 68
    CODE39 = 69
    ITF = 70
    CODABAR = 71
    CODE93 = 72
    CODE128 = 73

    def __init__(
        self, uart, byte_delay_s=0.00057346, dot_feed_s=0.0021, dot_print_s=0.03
    ):
        """Thermal printer class.  Requires a serial UART connection with at
        least the TX pin connected.  Take care connecting RX as the printer
        will output a 5V signal which can damage boards!  If RX is unconnected
        the only loss in functionality is the has_paper function, all other
        printer functions will continue to work.  The byte_delay_s, dot_feed_s,
        and dot_print_s values are delays which are used to prevent overloading
        the printer with data.  Use the default delays unless you fully
        understand the workings of the printer and how delays, baud rate,
        number of dots, heat time, etc. relate to each other.
        """
        super().__init__(
            uart,
            byte_delay_s=byte_delay_s,
            dot_feed_s=dot_feed_s,
            dot_print_s=dot_print_s, (duplicate-code)
```